### PR TITLE
Rudimentary tracked-env control

### DIFF
--- a/conda_env_tracker/__init__.py
+++ b/conda_env_tracker/__init__.py
@@ -1,1 +1,3 @@
 __version__ = '0.1.0'
+
+manifest_branch_prefix = 'manifest/'

--- a/conda_env_tracker/deploy.py
+++ b/conda_env_tracker/deploy.py
@@ -108,6 +108,11 @@ def deploy_repo(repo, target):
             manifest_branch = repo.branches[manifest_branch_name]
             branch.checkout()
             labelled_tags = tags_by_label(os.path.join(repo.working_dir, 'labels'))
+            # We want to deploy all tags which have a label, as well as the latest tag.
+            if env_tags.get(branch.name):
+                latest_tag = max(env_tags[branch.name],
+                                 key=lambda t: t.commit.committed_date)
+                labelled_tags['latest'] = latest_tag.name
             for tag in set(labelled_tags.values()):
                 deploy_tag(repo, tag, target)
             for label, tag in labelled_tags.items():

--- a/conda_env_tracker/deploy.py
+++ b/conda_env_tracker/deploy.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import datetime
+from glob import glob
+import os
+import time
+
+from git import Repo
+import conda.api
+import conda.fetch
+from conda_env_tracker.cli import tempdir, create_tracking_branches
+from conda_execute.lock import Locked
+
+manifest_branch_prefix = 'manifest/'
+
+
+def tags_by_label(repo, env_branch):
+    env_branch.checkout()
+    label_dir = os.path.join(repo.working_dir, 'labels')
+    tags = {}
+    if os.path.isdir(label_dir):
+        for label_fname in glob(os.path.join(label_dir, '*.txt')):
+            with open(label_fname, 'r') as fh:
+                tag = fh.read()
+            label = os.path.splitext(os.path.basename(label_fname))[0]
+            tags[label] = tag
+    return tags
+
+
+def deploy_tag(repo, tag_name, target):
+    tag = repo.tags[tag_name]
+    # Checkout the tag in a detached head form.
+    repo.head.reference = tag.commit
+    repo.head.reset(working_tree=True)
+
+    # Pull out the environment name from the form "env_<env_name>_2000_12_25".
+    env_name = tag_name.split('-')[1]
+    deployed_name = tag_name.split('-', 2)[2]
+
+    manifest_fname = os.path.join(repo.working_dir, 'env.manifest')
+    if not os.path.exists(manifest_fname):
+        raise ValueError("The tag '{}' doesn't have a manifested environment.".format(tag_name))
+    with open(manifest_fname, 'r') as fh:
+        manifest = sorted(line.strip().split('\t') for line in fh)
+    index = conda.api.get_index()
+    create_env(manifest, os.path.join(target, env_name, deployed_name), os.path.join(target, '.pkg_cache'))
+
+
+def create_env(pkgs, target, pkg_cache):
+    # We lock the specific environment we are wanting to create. If other requests come in for the
+    # exact same environment, they will have to wait for this to finish (good).
+    with Locked(target):
+        if os.path.exists(target):
+            # The environment we want to deploy already exists. We should just double check that
+            # there aren't already packages in there which we need to remove before we install anything
+            # new.
+            for pkg in conda.install.linked(target):
+                if pkg + '.tar.bz2' not in pkgs:
+                    conda.install.unlink(target, pkg)
+
+        for source, pkg in pkgs:
+            index = conda.fetch.fetch_index([source], use_cache=True)
+            tar_name = pkg + '.tar.bz2'
+            pkg_info = index.get(tar_name, None)
+            if pkg_info is None:
+                raise ValueError('Distribution {} is no longer available in the channel.'.format(tar_name))
+            dist_name = pkg 
+            # We force a lock on retrieving anything which needs access to a distribution of this
+            # name. If other requests come in to get the exact same package they will have to wait
+            # for this to finish (good). If conda itself it fetching these pacakges then there is
+            # the potential for a race condition (bad) - there is no solution to this unless
+            # conda/conda is updated to be more precise with its locks.
+            lock_name = os.path.join(pkg_cache, dist_name)
+            with Locked(lock_name):
+                if not conda.install.is_extracted(pkg_cache, dist_name):
+                    if not conda.install.is_fetched(pkg_cache, dist_name):
+                        print('Fetching {}'.format(dist_name))
+                        conda.fetch.fetch_pkg(pkg_info, pkg_cache)
+                    conda.install.extract(pkg_cache, dist_name)
+                conda.install.link(pkg_cache, target, dist_name)
+
+
+def deploy_repo(repo, target):
+    for branch in repo.branches:
+        # We only want environment branches, not manifest branches.
+        if not branch.name.startswith(manifest_branch_prefix):
+            manifest_branch_name = manifest_branch_prefix + branch.name
+            # If there is no equivalent manifest branch, we need to
+            # skip this environment.
+            if manifest_branch_name not in repo.branches:
+                continue
+            manifest_branch = repo.branches[manifest_branch_name]
+            labelled_tags = tags_by_label(repo, branch)
+            for tag in set(labelled_tags.values()):
+                deploy_tag(repo, tag, target)
+            for label, tag in labelled_tags.items():
+                with Locked(os.path.join(target, label)):
+                    deployed_name = tag.split('-', 2)[2]
+                    label_target = deployed_name
+                    label_location = os.path.join(target, branch.name, label)
+
+                    if os.path.exists(label_location):
+                        # Unix only:
+                        if os.readlink(label_location) != label_target:
+                            os.remove(label_location)
+                   
+                    if not os.path.exists(label_location):
+                        print('Linking {}/{} to {}'.format(branch.name, label, tag))
+                        os.symlink(label_target, label_location)
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Deploy the tracked environments.')
+    parser.add_argument('repo_uri', help='Repo to deploy.')
+    parser.add_argument('target', help='Location to deploy the environments to.')
+    args = parser.parse_args()
+
+    with tempdir() as repo_directory:
+        repo = Repo.clone_from(args.repo_uri, repo_directory)
+        create_tracking_branches(repo)
+        deploy_repo(repo, args.target)
+
+
+if __name__ == '__main__':
+    main()

--- a/conda_env_tracker/deploy.py
+++ b/conda_env_tracker/deploy.py
@@ -12,7 +12,7 @@ import conda.fetch
 from conda_env_tracker.cli import tempdir, create_tracking_branches
 from conda_execute.lock import Locked
 
-manifest_branch_prefix = 'manifest/'
+from conda_env_tracker import manifest_branch_prefix
 
 
 def tags_by_label(labels_directory):

--- a/conda_env_tracker/label_tag.py
+++ b/conda_env_tracker/label_tag.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import datetime
+from itertools import izip_longest
+import os
+import shutil
+import time
+
+from git import Repo
+from conda_env_tracker.cli import tempdir, create_tracking_branches
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Update the next, current and previous labels of the given managed environment.')
+    parser.add_argument('repo_uri', help='The repo to push the labels to.')
+    parser.add_argument('next_tag', help='The tag to use for "next". The environment is deduced from that in the tag name.')
+    parser.add_argument('--next-only', help='Whether to only update "next" and not current & previous.', action='store_true')
+    args = parser.parse_args()
+
+    with tempdir() as repo_directory:
+        repo = Repo.clone_from(args.repo_uri, repo_directory)
+        create_tracking_branches(repo)
+        # Pull out the environment name from the form "env_<env_name>_2000_12_25".
+        environment_name = args.next_tag.rsplit('_', 3)[0].split('_', 1)[1]
+        env_branch = repo.branches[environment_name]
+        env_branch.checkout()
+        
+        if not args.next_tag in repo.tags:
+            raise RuntimeError('No tag {!r} exists in the repo.'.format(args.next_tag))
+
+        labels_dir = os.path.join(repo.working_dir, 'labels')
+        if not os.path.exists(labels_dir):
+            os.makedirs(labels_dir)
+
+        if args.next_only:
+            label_progression = []
+        else:
+            label_progression = [('previous', None), ('current', 'previous'), ('next', 'current')]
+
+        lbl_fname = lambda label: os.path.join(labels_dir, '{}.txt'.format(label))
+
+        for label, next_label in label_progression:
+            if os.path.exists(lbl_fname(label)):
+                if next_label is None:
+                    os.unlink(lbl_fname(label))
+                else:
+                    shutil.move(lbl_fname(label), lbl_fname(next_label))
+                    repo.index.add([lbl_fname(next_label)])
+
+        with open(lbl_fname('next'), 'w') as fh:
+            fh.write(args.next_tag)
+
+        repo.index.add([lbl_fname('next')])
+        commit = repo.index.commit('Updated {} label to {}.'.format('next', args.next_tag))
+        repo.remotes.origin.push(env_branch)
+
+
+if __name__ == '__main__':
+    main()

--- a/conda_env_tracker/label_tag.py
+++ b/conda_env_tracker/label_tag.py
@@ -47,6 +47,12 @@ def progress_label(repo, next_tag, next_only=False):
     return env_branch
 
 
+def write_labels(labels_dir, labels):
+    for label, tag in labels.items():
+        label_fname = os.path.join(labels_dir, '{}.txt'.format(label))
+        with open(label_fname, 'w') as fh:
+            fh.write(tag)
+
 def main():
     import argparse
 

--- a/conda_env_tracker/tag_dates.py
+++ b/conda_env_tracker/tag_dates.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import datetime
+import time
+
+from git import Repo
+from conda_env_tracker.cli import tempdir, create_tracking_branches
+
+
+manifest_branch_prefix = 'manifest/'
+
+
+def tag_by_branch(repo):
+    # Iterate through each of the branches, and tag any changes with
+    # the branch's commit timestamp.
+    repo_tags_by_commit = {tag.commit: tag for tag in repo.tags}
+    for branch in repo.branches:
+        if branch.name.startswith(manifest_branch_prefix):
+            sha = branch.commit
+            env_name = branch.name[len(manifest_branch_prefix):]
+            commit_date = datetime.datetime(*time.gmtime(sha.committed_date)[:6])
+            if sha not in repo_tags_by_commit:
+                tag = repo.create_tag('env_{}_{:%Y_%m_%d}'.format(env_name, commit_date), ref=branch,
+                                              message="Automatic tag of {}.".format(env_name))
+                yield tag
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Tag manifested environments based on the commit timestamp.')
+    parser.add_argument('repo_uri', help='Repo to push tags to.')
+    args = parser.parse_args()
+
+    with tempdir() as repo_directory:
+        repo = Repo.clone_from(args.repo_uri, repo_directory)
+        create_tracking_branches(repo)
+        for tag in tag_by_branch(repo):
+            print('Pushing tag {}'.format(tag.name))
+            repo.remotes.origin.push(tag)
+
+
+if __name__ == '__main__':
+    main()

--- a/conda_env_tracker/tag_dates.py
+++ b/conda_env_tracker/tag_dates.py
@@ -21,8 +21,13 @@ def tag_by_branch(repo):
             env_name = branch.name[len(manifest_branch_prefix):]
             commit_date = datetime.datetime(*time.gmtime(sha.committed_date)[:6])
             if sha not in repo_tags_by_commit:
-                tag = repo.create_tag('env_{}_{:%Y_%m_%d}'.format(env_name, commit_date), ref=branch,
-                                              message="Automatic tag of {}.".format(env_name))
+                tag_prefix = 'env-{}-{:%Y_%m_%d}'.format(env_name, commit_date)
+                count, proposed_tag = 0, tag_prefix
+                while proposed_tag in repo.tags:
+                    count += 1
+                    proposed_tag = '{}-{}'.format(tag_prefix, count)
+                tag = repo.create_tag(proposed_tag, ref=branch,
+                                      message="Automatic tag of {}.".format(env_name))
                 yield tag
 
 

--- a/conda_env_tracker/tests/integration/setup_samples.py
+++ b/conda_env_tracker/tests/integration/setup_samples.py
@@ -19,13 +19,17 @@ def create_repo(name):
 
 def add_env(repo, name, spec):
     branch = repo.create_head(name)
+    update_env(repo, branch, spec)
+    return branch
+
+
+def update_env(repo, branch, spec):
     branch.checkout()
     env_spec = os.path.join(repo.working_dir, 'env.spec')
     with open(env_spec, 'w') as fh:
         fh.write(textwrap.dedent(spec))
     repo.index.add([env_spec])
-    repo.index.commit('Add {} spec'.format(name))
-    return branch
+    repo.index.commit('Add {} spec'.format(branch.name))
 
 
 def basic_repo():

--- a/conda_env_tracker/tests/integration/test_cli.py
+++ b/conda_env_tracker/tests/integration/test_cli.py
@@ -17,9 +17,10 @@ class Test_full_build(unittest.TestCase):
         manifest_branch.checkout()
         with open(os.path.join(repo.working_dir, 'env.manifest'), 'r') as fh:
             manifest_contents = fh.readlines()
-            pkg_names = [pkg.split('-', 1)[0] for pkg in manifest_contents]
+            pkg_names = [pkg.split('\t', 1)[1].split('-')[0] for pkg in manifest_contents]
             self.assertIn('python', pkg_names)
             self.assertIn('zlib', pkg_names)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/conda_env_tracker/tests/integration/test_cli_build_manifest_branches.py
+++ b/conda_env_tracker/tests/integration/test_cli_build_manifest_branches.py
@@ -40,7 +40,7 @@ class Test_full_build(unittest.TestCase):
             manifest.checkout()
             with open(os.path.join(repo.working_dir, 'env.manifest'), 'r') as fh:
                 manifest_contents = fh.readlines()
-            pkg_names = [pkg.split('-', 1)[0] for pkg in manifest_contents]
+            pkg_names = [pkg.split('\t', 1)[1].split('-')[0] for pkg in manifest_contents]
             self.assertIn('python', pkg_names)
             self.assertIn('zlib', pkg_names)
 

--- a/conda_env_tracker/tests/integration/test_deploy.py
+++ b/conda_env_tracker/tests/integration/test_deploy.py
@@ -1,0 +1,66 @@
+import contextlib
+import os
+import textwrap
+import unittest
+
+from git import Repo
+from conda_env_tracker import cli, tag_dates, label_tag, deploy
+from setup_samples import create_repo, add_env, update_env
+
+
+class Test(unittest.TestCase):
+    def setUp(self):
+        # Creates a new repo which is updated by conda-env-tracker
+        repo = create_repo('deployable_2_envs')
+        default = add_env(repo, 'default', """
+            env:
+             - python
+            channels:
+             - defaults 
+            """)
+        cli.build_manifest_branches(repo)
+
+        bleeding = add_env(repo, 'bleeding', """
+            env:
+             - python >2
+             - numpy
+            channels:
+             - defaults 
+            """)
+        cli.build_manifest_branches(repo)
+        for tag in tag_dates.tag_by_branch(repo):
+            label_tag.progress_label(repo, tag.name)
+
+        update_env(repo, default, """
+            env:
+             - python 2.*
+            channels: 
+             - defaults 
+            """)
+        cli.build_manifest_branches(repo)
+        for tag in tag_dates.tag_by_branch(repo):
+            self.default_next_tag = tag.name
+            label_tag.progress_label(repo, tag.name)
+
+        self.repo = repo
+
+    def test(self):
+        with cli.tempdir() as tmpdir:
+            tmpdir = '/downloads/foobar'
+            deploy.deploy_repo(self.repo, tmpdir)
+
+            def link_target(env, label):
+                link = os.path.join(tmpdir, env, label)
+                target = os.path.join(tmpdir, env, os.readlink(link))
+                return target 
+
+            self.assertTrue(os.path.exists(link_target('default', 'next')))
+            self.assertTrue(os.path.exists(link_target('default', 'current')))
+            self.assertTrue(os.path.exists(link_target('bleeding', 'next')))
+
+            # Check that we can resolve those links, finding the python executable.
+            self.assertTrue(os.path.exists(os.path.join(tmpdir, 'bleeding', 'next', 'bin', 'python')))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/conda_env_tracker/tests/integration/test_deploy.py
+++ b/conda_env_tracker/tests/integration/test_deploy.py
@@ -57,6 +57,8 @@ class Test(unittest.TestCase):
             self.assertTrue(os.path.exists(link_target('default', 'next')))
             self.assertTrue(os.path.exists(link_target('default', 'current')))
             self.assertTrue(os.path.exists(link_target('bleeding', 'next')))
+            self.assertTrue(os.path.exists(link_target('bleeding', 'latest')))
+            self.assertTrue(os.path.exists(link_target('default', 'latest')))
 
             # Check that we can resolve those links, finding the python executable.
             self.assertTrue(os.path.exists(os.path.join(tmpdir, 'bleeding', 'next', 'bin', 'python')))

--- a/conda_env_tracker/tests/integration/test_label_tags.py
+++ b/conda_env_tracker/tests/integration/test_label_tags.py
@@ -1,0 +1,90 @@
+import contextlib
+import os
+import textwrap
+import unittest
+from subprocess import check_call
+
+import setup_samples
+from conda_env_tracker.tag_dates import tag_by_branch
+
+
+class Test_cli(unittest.TestCase):
+    def test(self):
+        repo = setup_samples.create_repo('labelled_tags')
+
+        tag1 = 'env_example_env_1971_02_28'
+        tag2 = 'env_example_env_1972_03_31'
+        tag3 = 'env_example_env_1973_05_31'
+        tag4 = 'env_example_env_1974_05_31'
+
+        branch = repo.create_head('example_env')
+        manifest_branch = repo.create_head('manifest/example_env')
+        repo.create_tag(tag1, manifest_branch)
+
+        labels_dir = os.path.join(repo.working_dir, 'labels')
+        next_fname = os.path.join(labels_dir, 'next.txt')
+        prev_fname = os.path.join(labels_dir, 'previous.txt')
+        current_fname = os.path.join(labels_dir, 'current.txt')
+
+        branch.checkout()
+        self.assertFalse(os.path.exists(labels_dir))
+        # Checkout a different branch so that we can checkout the changes later on.
+        manifest_branch.checkout()
+        check_call(['conda-env-tracker-labeltag', repo.working_dir, tag1])
+
+        branch.checkout()
+        self.assertTrue(os.path.exists(labels_dir))
+
+        with open(next_fname, 'r') as fh:
+            next_label = fh.read()
+        self.assertEqual(next_label, tag1)
+        self.assertFalse(os.path.exists(prev_fname))
+        self.assertFalse(os.path.exists(current_fname))
+
+        # Now add another tag, and move it through the process.
+        repo.create_tag(tag2, manifest_branch)
+        manifest_branch.checkout()
+        check_call(['conda-env-tracker-labeltag', repo.working_dir, tag2])
+
+        branch.checkout()
+        with open(next_fname, 'r') as fh:
+            next_label = fh.read()
+        self.assertEqual(next_label, tag2)
+        with open(current_fname, 'r') as fh:
+            current_label = fh.read()
+        self.assertEqual(current_label, tag1)
+        self.assertFalse(os.path.exists(prev_fname))
+
+        # Now add another tag, but only update the "next" label..
+        repo.create_tag(tag3, manifest_branch)
+        manifest_branch.checkout()
+        check_call(['conda-env-tracker-labeltag', repo.working_dir, tag3, '--next-only'])
+
+        branch.checkout()
+        with open(next_fname, 'r') as fh:
+            next_label = fh.read()
+        self.assertEqual(next_label, tag3)
+        with open(current_fname, 'r') as fh:
+            current_label = fh.read()
+        self.assertEqual(current_label, tag1)
+        self.assertFalse(os.path.exists(prev_fname))
+
+        # Now add another tag, and move it through the process.
+        repo.create_tag(tag4, manifest_branch)
+        manifest_branch.checkout()
+        check_call(['conda-env-tracker-labeltag', repo.working_dir, tag4])
+
+        branch.checkout()
+        with open(next_fname, 'r') as fh:
+            next_label = fh.read()
+        self.assertEqual(next_label, tag4)
+        with open(current_fname, 'r') as fh:
+            current_label = fh.read()
+        self.assertEqual(current_label, tag3)
+        with open(prev_fname, 'r') as fh:
+            prev_label = fh.read()
+        self.assertEqual(prev_label, tag1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/conda_env_tracker/tests/integration/test_label_tags.py
+++ b/conda_env_tracker/tests/integration/test_label_tags.py
@@ -12,10 +12,10 @@ class Test_cli(unittest.TestCase):
     def test(self):
         repo = setup_samples.create_repo('labelled_tags')
 
-        tag1 = 'env_example_env_1971_02_28'
-        tag2 = 'env_example_env_1972_03_31'
-        tag3 = 'env_example_env_1973_05_31'
-        tag4 = 'env_example_env_1974_05_31'
+        tag1 = 'env-example_env-1971_02_28'
+        tag2 = 'env-example_env-1972_03_31'
+        tag3 = 'env-example_env-1973_05_31'
+        tag4 = 'env-example_env-1974_05_31'
 
         branch = repo.create_head('example_env')
         manifest_branch = repo.create_head('manifest/example_env')

--- a/conda_env_tracker/tests/integration/test_tag_dates.py
+++ b/conda_env_tracker/tests/integration/test_tag_dates.py
@@ -1,0 +1,31 @@
+import contextlib
+import os
+import textwrap
+import unittest
+from subprocess import check_call
+
+import setup_samples
+from conda_env_tracker.tag_dates import tag_by_branch
+
+
+class Test_tag_by_date(unittest.TestCase):
+    def test(self):
+        repo = setup_samples.create_repo('tag_by_date')
+        env = repo.create_head('manifest/example_env')
+        new_tags = list(tag_by_branch(repo))
+        self.assertEqual(len(new_tags), 1)
+        self.assertEqual(new_tags[0].commit, env.commit)
+
+
+class Test_cli(unittest.TestCase):
+    def test(self):
+        repo = setup_samples.create_repo('tag_by_date')
+        env = repo.create_head('manifest/example_env')
+                 
+        check_call(['conda-env-tracker-timestamp', repo.working_dir])
+
+        self.assertEqual(repo.tags[0].commit, env.commit)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/conda_env_tracker/tests/unit/test_deploy.py
+++ b/conda_env_tracker/tests/unit/test_deploy.py
@@ -1,0 +1,56 @@
+import contextlib
+import os
+import textwrap
+import unittest
+
+from git import Repo
+from conda_env_tracker import cli, tag_dates, label_tag, deploy
+from conda_env_tracker.tests.integration.setup_samples import create_repo
+
+
+class Test_tags_by_env(unittest.TestCase):
+    def setUp(self):
+        self.repo = create_repo('env_tags')
+
+    def assert_tagnamed(self, result, expected):
+        # Converts tag instances to strings for easy testing.
+        result_tag_name = {env: sorted(tag.name for tag in tags)
+                           for env, tags in result.items()}
+        self.assertEqual(result_tag_name, expected)
+
+    def test_no_tags(self):
+        r = deploy.tags_by_env(self.repo)
+        self.assertEqual(r, {})
+
+    def test_simple_tag(self):
+        self.repo.create_tag('env-testing-abc')
+        r = deploy.tags_by_env(self.repo)
+        self.assert_tagnamed(r, {'testing': ['env-testing-abc']})
+
+    def test_multiple_tags(self):
+        self.repo.create_tag('env-testing2-1')
+        self.repo.create_tag('env-testing1-2')
+        self.repo.create_tag('env-testing1-1')
+        r = deploy.tags_by_env(self.repo)
+        self.assert_tagnamed(r, {'testing1': ['env-testing1-1', 'env-testing1-2'],
+                                 'testing2': ['env-testing2-1']})
+
+
+class Test_tags_by_label(unittest.TestCase):
+    def test_no_tags(self):
+        expected = {}
+        with cli.tempdir() as labels_dir:
+            label_tag.write_labels(labels_dir, expected)
+            result = deploy.tags_by_label(labels_dir)
+        self.assertEqual(result, expected)
+
+    def test_some(self):
+        expected = {'a': '123', 'abc123': 'foobar-again'}
+        with cli.tempdir() as labels_dir:
+            label_tag.write_labels(labels_dir, expected)
+            result = deploy.tags_by_label(labels_dir)
+        self.assertEqual(result, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 gitpython
-yaml
+pyyaml
 conda-execute

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
       entry_points={
           'console_scripts': [
               'conda-env-tracker = conda_env_tracker.cli:main',
+              'conda-env-tracker-timestamp = conda_env_tracker.tag_dates:main',
           ]
       },
      )

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
           'console_scripts': [
               'conda-env-tracker = conda_env_tracker.cli:main',
               'conda-env-tracker-timestamp = conda_env_tracker.tag_dates:main',
+              'conda-env-tracker-labeltag = conda_env_tracker.label_tag:main',
           ]
       },
      )

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
               'conda-env-tracker = conda_env_tracker.cli:main',
               'conda-env-tracker-timestamp = conda_env_tracker.tag_dates:main',
               'conda-env-tracker-labeltag = conda_env_tracker.label_tag:main',
+              'conda-env-tracker-deploy = conda_env_tracker.deploy:main',
           ]
       },
      )


### PR DESCRIPTION
Adds the ability to:
- Automatically tag branch heads based on their commit date in the form `"tag_(env_name)_%Y_%m_%d"`
- Control next, current and previous tags with an interface.
