### PR TITLE
Added the conda-gitenv subcommands into a common cli.

### DIFF
--- a/conda_env_tracker/cli.py
+++ b/conda_env_tracker/cli.py
@@ -1,130 +1,25 @@
 #!/usr/bin/env python
 
-# conda execute
-# env:
-#  - gitpython
-#  - conda-execute
-#  - yaml
-# channels:
-#  - minadyn
-#  - conda-forge
-
 from __future__ import print_function
+import argparse
 
-import datetime
-import contextlib
-import logging
-import os
-import shutil
-import tempfile
+import conda_env_tracker.resolve as resolve
+import conda_env_tracker.tag_dates as tag_dates
+import conda_env_tracker.label_tag as label_tag
+import conda_env_tracker.deploy as deploy
 
-import conda.resolve
-import conda.api
-import conda_execute.config
-from git import Repo
-import yaml
-
-from conda_env_tracker import manifest_branch_prefix
-
-
-def resolve_spec(spec_fh):
-    """
-    Given an open file handle to an env.spec, return a list of strings containing
-    '<channel_url>\t<pkg_name>' for each package resolved.
-
-    """
-    spec = yaml.safe_load(spec_fh)
-    env_spec = spec.get('env', [])
-    index = conda.api.get_index(spec.get('channels', []), use_cache=True)
-    solver = conda.resolve.Resolve(index)
-    full_list_of_packages = sorted(solver.solve(env_spec), key=lambda pkg: pkg.lower())
-    pkgs = []
-    for pkg in full_list_of_packages:
-        r = index[pkg]
-        pkgs.append('\t'.join([r['channel'], pkg[:-len('.tar.bz2')]])), 
-    return pkgs
-
-
-def build_manifest_branches(repo):
-    for remote in repo.remotes:
-        remote.fetch()
-
-    for branch in repo.branches:
-        name = branch.name
-        if name.startswith(manifest_branch_prefix):
-            continue
-        branch.checkout()
-        spec_fname = os.path.join(repo.working_dir, 'env.spec')
-        if not os.path.exists(spec_fname):
-            # Skip branches which don't have a spec.
-            continue
-        with open(spec_fname, 'r') as fh:
-            pkgs = resolve_spec(fh)
-        manifest_branch_name = '{}{}'.format(manifest_branch_prefix, name)
-        if manifest_branch_name in repo.branches:
-            manifest_branch = repo.branches[manifest_branch_name]
-        else:
-            manifest_branch = repo.create_head(manifest_branch_name)
-        manifest_branch.checkout()
-        manifest_path = os.path.join(repo.working_dir, 'env.manifest')
-        with open(manifest_path, 'w') as fh:
-            fh.write('\n'.join(pkgs))
-        repo.index.add([manifest_path])
-        if repo.is_dirty():
-            repo.index.commit('Manifest update from {:%Y-%m-%d %H:%M:%S}.'
-                              ''.format(datetime.datetime.now()))
-
-
-@contextlib.contextmanager
-def tempdir(prefix='tmp'):
-    """A context manager for creating and then deleting a temporary directory."""
-    tmpdir = tempfile.mkdtemp(prefix=prefix)
-    try:
-        yield tmpdir
-    finally:
-        if os.path.isdir(tmpdir):
-            shutil.rmtree(tmpdir)
-
-
-def create_tracking_branches(repo):
-    """
-    Create local tracking branches for each of the remote's branches.
-    Ignore `HEAD` because it isn't a branch, and ignore the default
-    remote branch (e.g. `master`) because that will already have a
-    local tracking branch.
-
-    """
-    heads_to_skip = ['HEAD'] + [branch.name for branch in repo.branches]
-    for ref in repo.remotes.origin.refs:
-        if ref.remote_head not in heads_to_skip:
-            # Create the branch from the remote branch, and point it to
-            # track the origin's branch.
-            repo.create_head(ref.remote_head, ref).set_tracking_branch(ref)
-
-
+    
 def main():
-    import argparse
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(title='Manage conda environments through git repos')
 
-    parser = argparse.ArgumentParser(description='Track environment specifications using a git repo.')
-    parser.add_argument('repo_uri', help='Repo to use for environment tracking.')
-    parser.add_argument('--verbose', '-v', action='store_true')
+    resolve.configure_parser(subparsers.add_parser('resolve'))
+    tag_dates.configure_parser(subparsers.add_parser('autotag'))
+    label_tag.configure_parser(subparsers.add_parser('autolabel'))
+    deploy.configure_parser(subparsers.add_parser('deploy'))
+
     args = parser.parse_args()
-
-    log_level = logging.WARN
-    if args.verbose:
-        log_level = logging.DEBUG
-    conda_execute.config.setup_logging(log_level)
-
-    with tempdir() as repo_directory:
-        repo = Repo.clone_from(args.repo_uri, repo_directory)
-        create_tracking_branches(repo)
-        build_manifest_branches(repo)
-        for branch in repo.branches:
-            if branch.name.startswith(manifest_branch_prefix):
-                remote_branch = branch.tracking_branch()
-                if remote_branch is None or branch.commit != remote_branch.commit:
-                    print('Pushing changes to {}'.format(branch.name))
-                    repo.remotes.origin.push(branch)
+    return args.function(args)
 
 
 if __name__ == '__main__':

--- a/conda_env_tracker/resolve.py
+++ b/conda_env_tracker/resolve.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+
+# conda execute
+# env:
+#  - gitpython
+#  - conda-execute
+#  - yaml
+# channels:
+#  - minadyn
+#  - conda-forge
+
+from __future__ import print_function
+
+import datetime
+import contextlib
+import logging
+import os
+import shutil
+import tempfile
+
+import conda.resolve
+import conda.api
+import conda_execute.config
+from git import Repo
+import yaml
+
+from conda_env_tracker import manifest_branch_prefix
+
+
+def resolve_spec(spec_fh):
+    """
+    Given an open file handle to an env.spec, return a list of strings containing
+    '<channel_url>\t<pkg_name>' for each package resolved.
+
+    """
+    spec = yaml.safe_load(spec_fh)
+    env_spec = spec.get('env', [])
+    index = conda.api.get_index(spec.get('channels', []), use_cache=True)
+    solver = conda.resolve.Resolve(index)
+    full_list_of_packages = sorted(solver.solve(env_spec), key=lambda pkg: pkg.lower())
+    pkgs = []
+    for pkg in full_list_of_packages:
+        r = index[pkg]
+        pkgs.append('\t'.join([r['channel'], pkg[:-len('.tar.bz2')]])), 
+    return pkgs
+
+
+def build_manifest_branches(repo):
+    for remote in repo.remotes:
+        remote.fetch()
+
+    for branch in repo.branches:
+        name = branch.name
+        if name.startswith(manifest_branch_prefix):
+            continue
+        branch.checkout()
+        spec_fname = os.path.join(repo.working_dir, 'env.spec')
+        if not os.path.exists(spec_fname):
+            # Skip branches which don't have a spec.
+            continue
+        with open(spec_fname, 'r') as fh:
+            pkgs = resolve_spec(fh)
+        manifest_branch_name = '{}{}'.format(manifest_branch_prefix, name)
+        if manifest_branch_name in repo.branches:
+            manifest_branch = repo.branches[manifest_branch_name]
+        else:
+            manifest_branch = repo.create_head(manifest_branch_name)
+        manifest_branch.checkout()
+        manifest_path = os.path.join(repo.working_dir, 'env.manifest')
+        with open(manifest_path, 'w') as fh:
+            fh.write('\n'.join(pkgs))
+        repo.index.add([manifest_path])
+        if repo.is_dirty():
+            repo.index.commit('Manifest update from {:%Y-%m-%d %H:%M:%S}.'
+                              ''.format(datetime.datetime.now()))
+
+
+@contextlib.contextmanager
+def tempdir(prefix='tmp'):
+    """A context manager for creating and then deleting a temporary directory."""
+    tmpdir = tempfile.mkdtemp(prefix=prefix)
+    try:
+        yield tmpdir
+    finally:
+        if os.path.isdir(tmpdir):
+            shutil.rmtree(tmpdir)
+
+
+def create_tracking_branches(repo):
+    """
+    Create local tracking branches for each of the remote's branches.
+    Ignore `HEAD` because it isn't a branch, and ignore the default
+    remote branch (e.g. `master`) because that will already have a
+    local tracking branch.
+
+    """
+    heads_to_skip = ['HEAD'] + [branch.name for branch in repo.branches]
+    for ref in repo.remotes.origin.refs:
+        if ref.remote_head not in heads_to_skip:
+            # Create the branch from the remote branch, and point it to
+            # track the origin's branch.
+            repo.create_head(ref.remote_head, ref).set_tracking_branch(ref)
+
+
+def configure_parser(parser):
+    parser.add_argument('repo_uri', help='Repo to use for environment tracking.')
+    parser.add_argument('--verbose', '-v', action='store_true')
+    parser.set_defaults(function=handle_args)
+    return parser
+
+
+def handle_args(args):
+    log_level = logging.WARN
+    if args.verbose:
+        log_level = logging.DEBUG
+    conda_execute.config.setup_logging(log_level)
+
+    with tempdir() as repo_directory:
+        repo = Repo.clone_from(args.repo_uri, repo_directory)
+        create_tracking_branches(repo)
+        build_manifest_branches(repo)
+        for branch in repo.branches:
+            if branch.name.startswith(manifest_branch_prefix):
+                remote_branch = branch.tracking_branch()
+                if remote_branch is None or branch.commit != remote_branch.commit:
+                    print('Pushing changes to {}'.format(branch.name))
+                    repo.remotes.origin.push(branch)
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Track environment specifications using a git repo.')
+    configure_parser(parser)
+    args = parser.parse_args()
+    return args.function(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/conda_env_tracker/tag_dates.py
+++ b/conda_env_tracker/tag_dates.py
@@ -5,7 +5,7 @@ import datetime
 import time
 
 from git import Repo
-from conda_env_tracker.cli import tempdir, create_tracking_branches
+from conda_env_tracker.resolve import tempdir, create_tracking_branches
 
 
 manifest_branch_prefix = 'manifest/'
@@ -31,19 +31,28 @@ def tag_by_branch(repo):
                 yield tag
 
 
-def main():
-    import argparse
-
-    parser = argparse.ArgumentParser(description='Tag manifested environments based on the commit timestamp.')
+def configure_parser(parser):
     parser.add_argument('repo_uri', help='Repo to push tags to.')
-    args = parser.parse_args()
+    parser.set_defaults(function=handle_args)
+    return parser
 
+
+def handle_args(args):
     with tempdir() as repo_directory:
         repo = Repo.clone_from(args.repo_uri, repo_directory)
         create_tracking_branches(repo)
         for tag in tag_by_branch(repo):
             print('Pushing tag {}'.format(tag.name))
             repo.remotes.origin.push(tag)
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Tag manifested environments based on the commit timestamp.')
+    configure_parser(parser)
+    args = parser.parse_args()
+    args.function(args)
 
 
 if __name__ == '__main__':

--- a/conda_env_tracker/tests/integration/test_cli_build_manifest_branches.py
+++ b/conda_env_tracker/tests/integration/test_cli_build_manifest_branches.py
@@ -4,13 +4,13 @@ import textwrap
 import unittest
 
 from git import Repo
-from conda_env_tracker import cli
+from conda_env_tracker import resolve
 
 
 class Test_full_build(unittest.TestCase):
     @contextlib.contextmanager
     def create_repo(self):
-        with cli.tempdir() as tmpdir:
+        with resolve.tempdir() as tmpdir:
             repo = Repo.init(tmpdir)
             repo.index.commit('Initial commit.')
             yield repo
@@ -33,7 +33,7 @@ class Test_full_build(unittest.TestCase):
             channels:
              - defaults 
             """)
-            cli.build_manifest_branches(repo)
+            resolve.build_manifest_branches(repo)
 
             self.assertIn('manifest/master', repo.branches)
             manifest = repo.branches['manifest/master']

--- a/conda_env_tracker/tests/integration/test_deploy.py
+++ b/conda_env_tracker/tests/integration/test_deploy.py
@@ -4,7 +4,7 @@ import textwrap
 import unittest
 
 from git import Repo
-from conda_env_tracker import cli, tag_dates, label_tag, deploy
+from conda_env_tracker import resolve, tag_dates, label_tag, deploy
 from setup_samples import create_repo, add_env, update_env
 
 
@@ -18,7 +18,7 @@ class Test(unittest.TestCase):
             channels:
              - defaults 
             """)
-        cli.build_manifest_branches(repo)
+        resolve.build_manifest_branches(repo)
 
         bleeding = add_env(repo, 'bleeding', """
             env:
@@ -27,7 +27,7 @@ class Test(unittest.TestCase):
             channels:
              - defaults 
             """)
-        cli.build_manifest_branches(repo)
+        resolve.build_manifest_branches(repo)
         for tag in tag_dates.tag_by_branch(repo):
             label_tag.progress_label(repo, tag.name)
 
@@ -37,7 +37,7 @@ class Test(unittest.TestCase):
             channels: 
              - defaults 
             """)
-        cli.build_manifest_branches(repo)
+        resolve.build_manifest_branches(repo)
         for tag in tag_dates.tag_by_branch(repo):
             self.default_next_tag = tag.name
             label_tag.progress_label(repo, tag.name)
@@ -45,8 +45,7 @@ class Test(unittest.TestCase):
         self.repo = repo
 
     def test(self):
-        with cli.tempdir() as tmpdir:
-            tmpdir = '/downloads/foobar'
+        with resolve.tempdir() as tmpdir:
             deploy.deploy_repo(self.repo, tmpdir)
 
             def link_target(env, label):

--- a/conda_env_tracker/tests/unit/test_deploy.py
+++ b/conda_env_tracker/tests/unit/test_deploy.py
@@ -4,7 +4,7 @@ import textwrap
 import unittest
 
 from git import Repo
-from conda_env_tracker import cli, tag_dates, label_tag, deploy
+from conda_env_tracker import resolve, tag_dates, label_tag, deploy
 from conda_env_tracker.tests.integration.setup_samples import create_repo
 
 
@@ -39,14 +39,14 @@ class Test_tags_by_env(unittest.TestCase):
 class Test_tags_by_label(unittest.TestCase):
     def test_no_tags(self):
         expected = {}
-        with cli.tempdir() as labels_dir:
+        with resolve.tempdir() as labels_dir:
             label_tag.write_labels(labels_dir, expected)
             result = deploy.tags_by_label(labels_dir)
         self.assertEqual(result, expected)
 
     def test_some(self):
         expected = {'a': '123', 'abc123': 'foobar-again'}
-        with cli.tempdir() as labels_dir:
+        with resolve.tempdir() as labels_dir:
             label_tag.write_labels(labels_dir, expected)
             result = deploy.tags_by_label(labels_dir)
         self.assertEqual(result, expected)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ setup(
       packages=['conda_env_tracker'],
       entry_points={
           'console_scripts': [
-              'conda-env-tracker = conda_env_tracker.cli:main',
+              'conda-gitenv = conda_env_tracker.cli:main',
+              'conda-env-tracker = conda_env_tracker.resolve:main',
               'conda-env-tracker-timestamp = conda_env_tracker.tag_dates:main',
               'conda-env-tracker-labeltag = conda_env_tracker.label_tag:main',
               'conda-env-tracker-deploy = conda_env_tracker.deploy:main',


### PR DESCRIPTION
- Moved cli to a better name (resolve).
- Fixed hardcoded test directory

Closes #5.

Still to do after this PR:
- rename the import
- remove the old entry points
- add travis-ci testing
