### PR TITLE
Removed space before 'env' in here-document env.spec defined in READM…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ git checkout -b default
 cat <<EOF > env.spec
 channels:
  - defaults
- env: 
+env: 
  - python
 
 EOF


### PR DESCRIPTION
…E.md
