### PR TITLE
Add schannel to pkg name for conda cache lookup.

### DIFF
--- a/conda_gitenv/deploy.py
+++ b/conda_gitenv/deploy.py
@@ -90,7 +90,10 @@ def create_env(pkgs, target, pkg_cache):
             # conda/conda is updated to be more precise with its locks.
             lock_name = os.path.join(pkg_cache, dist_name)
             with Locked(lock_name):
-                schannel_dist_name='{}::{}'.format(pkg_info['schannel'], dist_name)
+                schannel_dist_name = dist_name
+                if pkg_info['schannel'] != 'defaults':
+                    schannel_dist_name='{}::{}'.format(pkg_info['schannel'],
+                                                       dist_name)
                 if not conda.install.is_extracted(schannel_dist_name):
                     if not conda.install.is_fetched(schannel_dist_name):
                         print('Fetching {}'.format(dist_name))

--- a/conda_gitenv/deploy.py
+++ b/conda_gitenv/deploy.py
@@ -90,12 +90,13 @@ def create_env(pkgs, target, pkg_cache):
             # conda/conda is updated to be more precise with its locks.
             lock_name = os.path.join(pkg_cache, dist_name)
             with Locked(lock_name):
-                if not conda.install.is_extracted(dist_name):
-                    if not conda.install.is_fetched(dist_name):
+                schannel_dist_name='{}::{}'.format(pkg_info['schannel'], dist_name)
+                if not conda.install.is_extracted(schannel_dist_name):
+                    if not conda.install.is_fetched(schannel_dist_name):
                         print('Fetching {}'.format(dist_name))
                         conda.fetch.fetch_pkg(pkg_info)
-                    conda.install.extract(dist_name)
-                conda.install.link(target, dist_name)
+                    conda.install.extract(schannel_dist_name)
+                conda.install.link(target, schannel_dist_name)
 
 
 def deploy_repo(repo, target):


### PR DESCRIPTION
@pelson Stumbled over this mismatch between the `conda.install.package_cache_` dictionary key pkg name and the usage of the stripped down pkg key within `deploy.create_env()`.

This fixes the following behaviour:

``` python
> conda gitenv deploy ${REPO_URL} target
Fetching package metadata ...Using Anaconda API: https://api.anaconda.org
.
Fetching anaconda-client-1.0.2-py27_0
Traceback (most recent call last):
  File "/data/local/itwl/miniconda2/envs/_test/bin/conda-gitenv", line 11, in <module>
    load_entry_point('conda-gitenv==0+unknown', 'console_scripts', 'conda-gitenv')()
  File "/data/local/itwl/miniconda2/envs/_test/lib/python2.7/site-packages/conda_gitenv/cli.py", line 22, in main
    return args.function(args)
  File "/data/local/itwl/miniconda2/envs/_test/lib/python2.7/site-packages/conda_gitenv/deploy.py", line 147, in handle_args
    deploy_repo(repo, args.target)
  File "/data/local/itwl/miniconda2/envs/_test/lib/python2.7/site-packages/conda_gitenv/deploy.py", line 120, in deploy_repo
    deploy_tag(repo, tag, target)
  File "/data/local/itwl/miniconda2/envs/_test/lib/python2.7/site-packages/conda_gitenv/deploy.py", line 52, in deploy_tag
    create_env(manifest, os.path.join(target, env_name, deployed_name), os.path.join(target, '.pkg_cache'))
  File "/data/local/itwl/miniconda2/envs/_test/lib/python2.7/site-packages/conda_gitenv/deploy.py", line 97, in create_env
    conda.install.extract(dist_name)
  File "/data/local/itwl/miniconda2/envs/_test/lib/python2.7/site-packages/conda/install.py", line 847, in extract
    rec = package_cache()[dist]
KeyError: 'anaconda-client-1.0.2-py27_0'
```
