### PR TITLE
Update with working conda-forge recipe.

### DIFF
--- a/conda-gitenv.recipe/meta.yaml
+++ b/conda-gitenv.recipe/meta.yaml
@@ -1,26 +1,31 @@
-{% set data = load_setuptools() %}
+{% set version = "0.2.0" %}
 
 package:
-    name: conda-gitenv
-    version: {{data.get('version')}}
+  name: conda-gitenv
+  version: {{ version }}
 
 source:
-    path: ../
+  fn: conda-gitenv-{{ version }}.tar.gz
+  url: https://github.com/SciTools/conda-gitenv/archive/v{{ version }}.tar.gz
+  sha256: afbcfea861c2fedecd640248a97f47b0538f29b7c3966eeaa724a7636d478633
 
 build:
-    script: python setup.py install --single-version-externally-managed --record=record.txt
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
-    build:
-        - python
-        - setuptools
-    run:
-        - python
-        - setuptools
-        - gitpython
-        - pyyaml
-        - conda >=4.1
-        - conda-build-all
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - setuptools
+    - gitpython
+    - pyyaml
+    - conda >=4.1.0
+    - conda-build-all
+    - conda-build !=2.0.9
 
 test:
   imports:
@@ -33,5 +38,14 @@ test:
     - conda gitenv deploy --help
 
 about:
-  license: BSD-3
-  home: https://github.com/scitools/conda-gitenv
+  home: https://github.com/SciTools/conda-gitenv
+  license: BSD 3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Track environment specifications using a git repo.'
+
+extra:
+  recipe-maintainers:
+    - pelson
+    - bjlittle
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 gitpython
 pyyaml
 conda-build-all
+conda-build ==2.0.6


### PR DESCRIPTION
We now have `conda-gitenv` on conda-forge, see https://github.com/conda-forge/staged-recipes/pull/1936 and https://github.com/conda-forge/conda-gitenv-feedstock.

This PR aligns the bundled recipe with that used in conda-forge