### PR TITLE
Set pkgs_dir to be pkg_cache and not PREFIX/pkgs.

### DIFF
--- a/conda_gitenv/deploy.py
+++ b/conda_gitenv/deploy.py
@@ -54,10 +54,14 @@ def deploy_tag(repo, tag_name, target):
 
 
 def create_env(pkgs, target, pkg_cache):
+    # Cache settings to be reinstated at the end.
+    orig_package_cache_ = conda.install.package_cache_
+    orig_pkgs_dirs = conda.install.pkgs_dirs
+
     # Empty package cache so that it will reinitialised.
     conda.install.package_cache_ = {}
-    # Set pkgs_dir location to be the specified pkg_cache.
-    conda.install.pkgs_dirs=[pkg_cache]
+    # Set pkgs_dirs location to be the specified pkg_cache.
+    conda.install.pkgs_dirs = [pkg_cache]
 
     # We lock the specific environment we are wanting to create. If other requests come in for the
     # exact same environment, they will have to wait for this to finish (good).
@@ -100,14 +104,15 @@ def create_env(pkgs, target, pkg_cache):
                 if pkg_info['schannel'] != 'defaults':
                     schannel_dist_name='{}::{}'.format(pkg_info['schannel'],
                                                        dist_name)
-
                 if not conda.install.is_extracted(schannel_dist_name):
                     if not conda.install.is_fetched(schannel_dist_name):
                         print('Fetching {}'.format(dist_name))
                         conda.fetch.fetch_pkg(pkg_info)
                     conda.install.extract(schannel_dist_name)
                 conda.install.link(target, schannel_dist_name)
-    conda.install.package_cache_ = {}
+
+    conda.install.package_cache_ = orig_package_cache_
+    conda.install.pkgs_dirs = orig_pkgs_dirs
 
 
 def deploy_repo(repo, target, desired_env_labels=('*')):

--- a/conda_gitenv/deploy.py
+++ b/conda_gitenv/deploy.py
@@ -35,7 +35,7 @@ def tags_by_env(repo):
     return tags
 
 
-def deploy_tag(repo, tag_name, target):
+def deploy_tag(repo, tag_name, target, pkg_cache):
     tag = repo.tags[tag_name]
     # Checkout the tag in a detached head form.
     repo.head.reference = tag.commit
@@ -50,19 +50,10 @@ def deploy_tag(repo, tag_name, target):
         raise ValueError("The tag '{}' doesn't have a manifested environment.".format(tag_name))
     with open(manifest_fname, 'r') as fh:
         manifest = sorted(line.strip().split('\t') for line in fh)
-    create_env(manifest, os.path.join(target, env_name, deployed_name), os.path.join(target, '.pkg_cache'))
+    create_env(manifest, os.path.join(target, env_name, deployed_name), pkg_cache)
 
 
 def create_env(pkgs, target, pkg_cache):
-    # Cache settings to be reinstated at the end.
-    orig_package_cache_ = conda.install.package_cache_
-    orig_pkgs_dirs = conda.install.pkgs_dirs
-
-    # Empty package cache so that it will reinitialised.
-    conda.install.package_cache_ = {}
-    # Set pkgs_dirs location to be the specified pkg_cache.
-    conda.install.pkgs_dirs = [pkg_cache]
-
     # We lock the specific environment we are wanting to create. If other requests come in for the
     # exact same environment, they will have to wait for this to finish (good).
     with Locked(target):
@@ -111,11 +102,18 @@ def create_env(pkgs, target, pkg_cache):
                     conda.install.extract(schannel_dist_name)
                 conda.install.link(target, schannel_dist_name)
 
-    conda.install.package_cache_ = orig_package_cache_
-    conda.install.pkgs_dirs = orig_pkgs_dirs
-
 
 def deploy_repo(repo, target, desired_env_labels=('*')):
+    # Cache settings to be reinstated at the end.
+    orig_package_cache_ = conda.install.package_cache_
+    orig_pkgs_dirs = conda.install.pkgs_dirs
+
+    # Empty package cache so that it will reinitialised.
+    conda.install.package_cache_ = {}
+    # Set pkgs_dirs location to be the specified pkg_cache.
+    pkg_cache = os.path.join(target, '.pkg_cache')
+    conda.install.pkgs_dirs = [pkg_cache]
+
     env_tags = tags_by_env(repo)
     for branch in repo.branches:
         # We only want environment branches, not manifest branches.
@@ -143,7 +141,7 @@ def deploy_repo(repo, target, desired_env_labels=('*')):
                     labelled_tags[label] = tag
 
             for tag in set(labelled_tags.values()):
-                deploy_tag(repo, tag, target)
+                deploy_tag(repo, tag, target, pkg_cache)
             for label, tag in labelled_tags.items():
                 with Locked(os.path.join(target, label)):
                     deployed_name = tag.split('-', 2)[2]
@@ -158,6 +156,10 @@ def deploy_repo(repo, target, desired_env_labels=('*')):
                     if not os.path.exists(label_location):
                         print('Linking {}/{} to {}'.format(branch.name, label, tag))
                         os.symlink(label_target, label_location)
+
+    conda.install.package_cache_ = orig_package_cache_
+    conda.install.pkgs_dirs = orig_pkgs_dirs
+
 
 def configure_parser(parser):
     parser.add_argument('repo_uri', help='Repo to deploy.')

--- a/conda_gitenv/deploy.py
+++ b/conda_gitenv/deploy.py
@@ -54,6 +54,11 @@ def deploy_tag(repo, tag_name, target):
 
 
 def create_env(pkgs, target, pkg_cache):
+    # Empty package cache so that it will reinitialised.
+    conda.install.package_cache_ = {}
+    # Set pkgs_dir location to be the specified pkg_cache.
+    conda.install.pkgs_dirs=[pkg_cache]
+
     # We lock the specific environment we are wanting to create. If other requests come in for the
     # exact same environment, they will have to wait for this to finish (good).
     with Locked(target):
@@ -95,13 +100,14 @@ def create_env(pkgs, target, pkg_cache):
                 if pkg_info['schannel'] != 'defaults':
                     schannel_dist_name='{}::{}'.format(pkg_info['schannel'],
                                                        dist_name)
-                conda.install.pkgs_dirs=[pkg_cache]
+
                 if not conda.install.is_extracted(schannel_dist_name):
                     if not conda.install.is_fetched(schannel_dist_name):
                         print('Fetching {}'.format(dist_name))
                         conda.fetch.fetch_pkg(pkg_info)
                     conda.install.extract(schannel_dist_name)
                 conda.install.link(target, schannel_dist_name)
+    conda.install.package_cache_ = {}
 
 
 def deploy_repo(repo, target, desired_env_labels=('*')):

--- a/conda_gitenv/deploy.py
+++ b/conda_gitenv/deploy.py
@@ -95,6 +95,7 @@ def create_env(pkgs, target, pkg_cache):
                 if pkg_info['schannel'] != 'defaults':
                     schannel_dist_name='{}::{}'.format(pkg_info['schannel'],
                                                        dist_name)
+                conda.install.pkgs_dirs=[pkg_cache]
                 if not conda.install.is_extracted(schannel_dist_name):
                     if not conda.install.is_fetched(schannel_dist_name):
                         print('Fetching {}'.format(dist_name))


### PR DESCRIPTION
Due to changes in conda, and the required subsequent [changes in conda-gitenv](https://github.com/SciTools/conda-gitenv/pull/22/files), conda-gitenv deploy no longer populates < target >.pkg_cache

* Conda 4.1.12 forces the pkgs_dirs (i.e. pkg_cache) to be [$PREFIX/pkgs](https://github.com/conda/conda/blob/4.1.12/conda/install.py#L97)
* the ["package_cache"](https://github.com/conda/conda/blob/4.1.12/conda/install.py#L714) uses that `pkgs_dirs
* the package_cache gets initialised when conda-gitenv  [calls `conda.install.is_extracted`](https://github.com/conda/conda/blob/4.1.12/conda/install.py#L817)

and so $PREFIX/pkgs gets populated rather than < target >.pkg_cache

This PR forces the pkg_cache to be what conda-gitenv wants it to be (< target >.pkg_cache)
