### PR TITLE
Pin requests to avoid broken version 2.12.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ gitpython
 pyyaml
 conda-build-all
 conda-build ==2.0.6
+requests !=2.12.0


### PR DESCRIPTION
Requests 2.12.0 causes problems with conda. This PR pins requests to not use the bad version.