### PR TITLE
Fix env.spec update in manifest branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
 
     # Now do the things we need to do to install it.
     - conda install --file requirements.txt nose mock python=${PYTHON} --yes --quiet -c conda-forge
+    - conda list
     - python setup.py install
 
 script:

--- a/conda_gitenv/lock.py
+++ b/conda_gitenv/lock.py
@@ -14,4 +14,6 @@ class Locked(conda.lock.Locked):
         """
         dirname, basename = os.path.split(directory_to_lock.rstrip(os.pathsep))
         path = os.path.join(dirname, '.conda-lock_' + basename)
+        if not os.path.isdir(dirname):
+            os.makedirs(dirname)
         return conda.lock.Locked.__init__(self, path)

--- a/conda_gitenv/resolve.py
+++ b/conda_gitenv/resolve.py
@@ -60,6 +60,9 @@ def build_manifest_branches(repo):
             continue
         with open(spec_fname, 'r') as fh:
             pkgs = resolve_spec(fh)
+            # Cache the contents of the env.spec file from the source branch.
+            fh.seek(0)
+            spec_lines = fh.readlines()
         manifest_branch_name = '{}{}'.format(manifest_branch_prefix, name)
         if manifest_branch_name in repo.branches:
             manifest_branch = repo.branches[manifest_branch_name]
@@ -69,7 +72,10 @@ def build_manifest_branches(repo):
         manifest_path = os.path.join(repo.working_dir, 'env.manifest')
         with open(manifest_path, 'w') as fh:
             fh.write('\n'.join(pkgs))
-        repo.index.add([manifest_path])
+        # Write the env.spec from the source branch into the manifest branch.
+        with open(spec_fname, 'w') as fh:
+            fh.writelines(spec_lines)
+        repo.index.add([manifest_path, spec_fname])
         if repo.is_dirty():
             repo.index.commit('Manifest update from {:%Y-%m-%d %H:%M:%S}.'
                               ''.format(datetime.datetime.now()))

--- a/conda_gitenv/tests/integration/setup_samples.py
+++ b/conda_gitenv/tests/integration/setup_samples.py
@@ -23,13 +23,15 @@ def add_env(repo, name, spec):
     return branch
 
 
-def update_env(repo, branch, spec):
+def update_env(repo, branch, spec, comment=None):
     branch.checkout()
     env_spec = os.path.join(repo.working_dir, 'env.spec')
     with open(env_spec, 'w') as fh:
         fh.write(textwrap.dedent(spec))
     repo.index.add([env_spec])
-    repo.index.commit('Add {} spec'.format(branch.name))
+    if comment is None:
+        comment = 'Add {} spec'.format(branch.name)
+    repo.index.commit(comment)
 
 
 def basic_repo():

--- a/conda_gitenv/tests/integration/setup_samples.py
+++ b/conda_gitenv/tests/integration/setup_samples.py
@@ -34,9 +34,9 @@ def update_env(repo, branch, spec, comment=None):
     repo.index.commit(comment)
 
 
-def basic_repo():
+def basic_repo(name='basic'):
     # The simplest kind of repo. One env defined under the name "master"
-    repo = create_repo('basic')
+    repo = create_repo(name)
     branch = add_env(repo, 'master', """
         env:
          - python

--- a/conda_gitenv/tests/integration/test_resolve.py
+++ b/conda_gitenv/tests/integration/test_resolve.py
@@ -8,8 +8,8 @@ import conda_gitenv.tests.integration.setup_samples as setup_samples
 
 
 class Test_full_build(unittest.TestCase):
-    def check_basic_env(self):
-        repo = setup_samples.basic_repo()
+    def check_env(self, name):
+        repo = setup_samples.basic_repo(name)
         self.assertNotIn('manifest/master', repo.branches)
         check_call(['conda', 'gitenv', 'resolve', repo.working_dir])
         self.assertIn('manifest/master', repo.branches)
@@ -23,11 +23,11 @@ class Test_full_build(unittest.TestCase):
             self.assertIn('zlib', pkg_names)
         return repo
 
-    def test_basic_env(self):
-        self.check_basic_env()
+    def test_env_basic(self):
+        self.check_env('basic')
 
-    def test_update_env(self):
-        repo = self.check_basic_env()
+    def test_env_update(self):
+        repo = self.check_env('update')
         master = repo.branches['master']
         spec = """
             env:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gitpython
 pyyaml
-conda-build-all
+conda-build-all !=1.0.2
 conda-build ==2.0.6
 requests <2.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pyyaml
 conda ==4.1.12
 conda-build-all
 conda-build ==2.0.6
-requests ==2.11.1 
+requests !=2.12.0 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 gitpython
 pyyaml
+conda ==4.1.12
 conda-build-all
 conda-build ==2.0.6
 requests !=2.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pyyaml
 conda ==4.1.12
 conda-build-all
 conda-build ==2.0.6
-requests !=2.12.0
+requests ==2.11.1 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 gitpython
 pyyaml
-conda ==4.1.12
 conda-build-all
 conda-build ==2.0.6
-requests !=2.12.0 
+requests <2.12.0


### PR DESCRIPTION
This PR provides a fix for the `resolve` action when performed on a existing `manifest` branch, to ensure that the `env.spec` file is appropriately updated to align with the `env.spec` from the original source branch that is being resolved.

Currently, we have the situation when a branch is being resolved, the `env.spec` file in the `manifest` branch is not being updated, but its contents remains the same as per the first time the branch is resolved.