### PR TITLE
Update to support at least conda 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ env:
 
     matrix:
         - PYTHON=2.7
-        - PYTHON=3.4
+        - PYTHON=3.5
+        - PYTHON=3.6
 
 install:
     - mkdir -p ${HOME}/cache/pkgs

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
 
     matrix:
         - PYTHON=2.7
-        - PYTHON=3.5
         - PYTHON=3.6
 
 install:

--- a/conda_gitenv/__init__.py
+++ b/conda_gitenv/__init__.py
@@ -1,6 +1,19 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from conda import __version__ as CONDA_VERSION
+
 from ._version import get_versions
+
+
+def _parse_conda_version_major_minor(string):
+    return string and tuple(int(x) for x in (string.split('.') + [0, 0])[:2]) or (0, 0)
+
+
 __version__ = get_versions()['version']
 del get_versions
 
+CONDA_VERSION_MAJOR_MINOR = _parse_conda_version_major_minor(CONDA_VERSION)
+conda_43 = CONDA_VERSION_MAJOR_MINOR >= (4, 3)
+assert conda_43, 'Minimum supported conda version is {}.{}'.format(*CONDA_VERSION_MAJOR_MINOR)
 
 manifest_branch_prefix = 'manifest/'

--- a/conda_gitenv/__init__.py
+++ b/conda_gitenv/__init__.py
@@ -11,7 +11,8 @@ __version__ = get_versions()['version']
 del get_versions
 
 _conda_base = StrictVersion('4.3.0')
-_conda_support = StrictVersion(CONDA_VERSION) >= _conda_base
-assert _conda_support, 'Minimum supported conda version is {}.'.format(_conda_base)
+_conda_version = StrictVersion(CONDA_VERSION)
+_conda_supported = _conda_version >= _conda_base
+assert _conda_support, 'Minimum supported conda version is {}, got {}.'.format(_conda_base, _conda_version)
 
 manifest_branch_prefix = 'manifest/'

--- a/conda_gitenv/__init__.py
+++ b/conda_gitenv/__init__.py
@@ -13,6 +13,6 @@ del get_versions
 _conda_base = StrictVersion('4.3.0')
 _conda_version = StrictVersion(CONDA_VERSION)
 _conda_supported = _conda_version >= _conda_base
-assert _conda_support, 'Minimum supported conda version is {}, got {}.'.format(_conda_base, _conda_version)
+assert _conda_supported, 'Minimum supported conda version is {}, got {}.'.format(_conda_base, _conda_version)
 
 manifest_branch_prefix = 'manifest/'

--- a/conda_gitenv/__init__.py
+++ b/conda_gitenv/__init__.py
@@ -1,19 +1,17 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from distutils.version import StrictVersion
+
 from conda import __version__ as CONDA_VERSION
 
 from ._version import get_versions
 
 
-def _parse_conda_version_major_minor(string):
-    return string and tuple(int(x) for x in (string.split('.') + [0, 0])[:2]) or (0, 0)
-
-
 __version__ = get_versions()['version']
 del get_versions
 
-CONDA_VERSION_MAJOR_MINOR = _parse_conda_version_major_minor(CONDA_VERSION)
-conda_43 = CONDA_VERSION_MAJOR_MINOR >= (4, 3)
-assert conda_43, 'Minimum supported conda version is {}.{}'.format(*CONDA_VERSION_MAJOR_MINOR)
+_conda_base = StrictVersion('4.3.0')
+_conda_support = StrictVersion(CONDA_VERSION) >= _conda_base
+assert _conda_support, 'Minimum supported conda version is {}.'.format(_conda_base)
 
 manifest_branch_prefix = 'manifest/'

--- a/conda_gitenv/deploy.py
+++ b/conda_gitenv/deploy.py
@@ -8,11 +8,10 @@ import os
 import time
 
 from git import Repo
-import conda.api
-import conda.fetch
+import yaml
 
-from conda_gitenv.resolve import tempdir, create_tracking_branches
 from conda_gitenv.lock import Locked
+from conda_gitenv.resolve import create_tracking_branches, tempdir
 from conda_gitenv import manifest_branch_prefix
 
 
@@ -50,87 +49,61 @@ def deploy_tag(repo, tag_name, target, pkg_cache):
         raise ValueError("The tag '{}' doesn't have a manifested environment.".format(tag_name))
     with open(manifest_fname, 'r') as fh:
         manifest = sorted(line.strip().split('\t') for line in fh)
-    create_env(manifest, os.path.join(target, env_name, deployed_name), pkg_cache)
+
+    target = os.path.join(target, env_name, deployed_name)
+    create_env(repo, manifest, target, pkg_cache)
 
 
-def create_env(pkgs, target, pkg_cache):
-    # We lock the specific environment we are wanting to create. If other requests come in for the
-    # exact same environment, they will have to wait for this to finish (good).
+def create_env(repo, pkgs, target, pkg_cache):
+    from conda.core.link import UnlinkLinkTransaction
+    from conda.core.package_cache import ProgressiveFetchExtract
+    from conda.exports import Resolve, fetch_index
+    from conda.models.channel import prioritize_channels
+    from conda.models.dist import Dist
+    from conda.gateways.disk.create import mkdir_p
+
+    spec_fname = os.path.join(repo.working_dir, 'env.spec')
+
+    # Skip branches that don't have an environment specification
+    if not os.path.exists(spec_fname):
+        return
+
     with Locked(target):
-        pkg_names = set(pkg for _, pkg in pkgs)
-        if os.path.exists(target):
-            # The environment we want to deploy already exists. We should just double check that
-            # there aren't already packages in there which we need to remove before we install anything
-            # new.
-            linked = conda.install.linked(target)
-            for pkg in linked:
-                if pkg not in pkg_names:
-                    conda.install.unlink(target, pkg)
-        else:
-            linked = []
+        with open(spec_fname, 'r') as fh:
+            spec = yaml.safe_load(fh)
 
-        if set(linked) == pkg_names:
-            # We don't need to re-link everything - it is already as expected.
-            # The downside is that we are not verifying that each package is installed correctly.
-            return
+        channels = prioritize_channels(spec.get('channels', []))
+        # Build reverse look-up from channel URL to channel name.
+        channel_by_url = {url: channel for url, (channel, _) in channels.items()}
+        index = fetch_index(channels, use_cache=False)
+        resolver = Resolve(index)
+        # Create the package distribution from the manifest. Ensure to replace
+        # channel-URLs with channel names, otherwise the fetch-extract may fail.
+        dists = [Dist.from_string(pkg, channel_override=channel_by_url.get(url, url)) for url, pkg in pkgs]
+        # Use the resolver to sort packages into the appropriate dependency
+        # order.
+        sorted_dists = resolver.dependency_sort({dist.name: dist for dist in dists})
 
-        try:
-            # Support conda>4.1
-            from conda.models.channel import prioritize_channels
-        except ImportError:
-            prioritize_channels = lambda nop: nop
-
-        for source, pkg in pkgs:
-            index = conda.fetch.fetch_index(prioritize_channels([source]), use_cache=False)
-            # Deal with the fact that a recent conda includes the source in the index key.
-            index = {pkg['fn']: pkg for pkg in index.values()}
-
-            tar_name = pkg + '.tar.bz2'
-            pkg_info = index.get(tar_name, None)
-            if pkg_info is None:
-                raise ValueError('Distribution {} is no longer available in the channel.'.format(tar_name))
-            dist_name = pkg 
-            # We force a lock on retrieving anything which needs access to a distribution of this
-            # name. If other requests come in to get the exact same package they will have to wait
-            # for this to finish (good). If conda itself it fetching these pacakges then there is
-            # the potential for a race condition (bad) - there is no solution to this unless
-            # conda/conda is updated to be more precise with its locks.
-            lock_name = os.path.join(pkg_cache, dist_name)
-            with Locked(lock_name):
-                schannel_dist_name = dist_name
-                if pkg_info['schannel'] != 'defaults':
-                    schannel_dist_name='{}::{}'.format(pkg_info['schannel'],
-                                                       dist_name)
-                if not conda.install.is_extracted(schannel_dist_name):
-                    if not conda.install.is_fetched(schannel_dist_name):
-                        print('Fetching {}'.format(dist_name))
-                        conda.fetch.fetch_pkg(pkg_info)
-                    conda.install.extract(schannel_dist_name)
-                conda.install.link(target, schannel_dist_name)
+        pfe = ProgressiveFetchExtract(index, dists)
+        pfe.execute()
+        mkdir_p(target)
+        txn = UnlinkLinkTransaction.create_from_dists(index, target, (), dists)
+        txn.execute()
 
 
 def deploy_repo(repo, target, desired_env_labels=None):
     # Set pkgs_dirs location to be the specified pkg_cache.
     # Cache settings to be reinstated at the end.
-    import conda
-    orig_package_cache_ = conda.install.package_cache_
-    pkg_cache = os.path.join(target, '.pkg_cache')
-    try:
-        # Support conda=4.1.*
-        orig_pkgs_dirs = conda.install.pkgs_dirs
-        conda.install.pkgs_dirs = [pkg_cache]
-    except AttributeError:
-        # Support conda>4.1
-        @property
-        def mocker(self):
-            return [pkg_cache]
-        import conda.base.context
-        orig_pkgs_dirs = conda.base.context.Context.pkgs_dirs
-        # Monkey patch the context instance property.
-        conda.base.context.Context.pkgs_dirs = mocker
+    import conda.base.context
 
-    # Empty package cache so that it will reinitialised.
-    conda.install.package_cache_ = {}
+    pkg_cache = os.path.join(target, '.pkg_cache')
+    @property
+    def mocker(self):
+        return (pkg_cache,)
+    orig_pkgs_dirs = conda.base.context.Context.pkgs_dirs
+    # Monkey patch the context pkgs_dirs property to override it
+    # with our custom package cache directory.
+    conda.base.context.Context.pkgs_dirs = mocker
 
     env_tags = tags_by_env(repo)
     for branch in repo.branches:
@@ -162,6 +135,7 @@ def deploy_repo(repo, target, desired_env_labels=None):
 
             for tag in set(labelled_tags.values()):
                 deploy_tag(repo, tag, target, pkg_cache)
+
             for label, tag in labelled_tags.items():
                 with Locked(os.path.join(target, label)):
                     deployed_name = tag.split('-', 2)[2]
@@ -177,12 +151,8 @@ def deploy_repo(repo, target, desired_env_labels=None):
                         print('Linking {}/{} to {}'.format(branch.name, label, tag))
                         os.symlink(label_target, label_location)
 
-    conda.install.package_cache_ = orig_package_cache_
-    if isinstance(orig_pkgs_dirs, property):
-        # Support conda>4.1
-        conda.base.context.Context.pkgs_dirs = orig_pkgs_dirs
-    else:
-        conda.install.pkgs_dirs = orig_pkgs_dirs
+    # Undo the monkey patch of the context pkgs_dirs property.
+    conda.base.context.Context.pkgs_dirs = orig_pkgs_dirs
 
 
 def configure_parser(parser):

--- a/conda_gitenv/resolve.py
+++ b/conda_gitenv/resolve.py
@@ -35,10 +35,12 @@ def resolve_spec(spec_fh):
     spec = yaml.safe_load(spec_fh)
     env_spec = spec.get('env', [])
     index = conda.api.get_index(spec.get('channels', []), prepend=False, use_cache=False)
-    solver = conda.resolve.Resolve(index)
-    full_list_of_packages = sorted(solver.solve(env_spec), key=lambda pkg: pkg.lower())
+    resolver = conda.resolve.Resolve(index)
+    packages = sorted(resolver.solve(env_spec),
+                      key=lambda pkg: pkg.dist_name.lower())
+
     pkgs = []
-    for pkg in full_list_of_packages:
+    for pkg in packages:
         pkg_info = index[pkg]
         pkgs.append('\t'.join([pkg_info['channel'],
                                pkg_info['fn'][:-len('.tar.bz2')]])), 

--- a/conda_gitenv/tests/unit/test_resolve.py
+++ b/conda_gitenv/tests/unit/test_resolve.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     from StringIO import StringIO
 
-import conda.resolve
+from conda.exceptions import NoPackagesFound
 
 from conda_gitenv.resolve import resolve_spec, tempdir
 from conda_build_all.tests.unit import dummy_index
@@ -27,9 +27,9 @@ class Test_resolve_spec(unittest.TestCase):
     def test(self):
         # Check that resolve_spec is returning the expected content.
         index = dummy_index.DummyIndex()
-        index.add_pkg('foo', '2.7.0', depends=('bar',))
-        index.add_pkg('foo', '3.5.0', depends=('bar',))
-        index.add_pkg('bar', '1.2')
+        index.add_pkg('foo', '2.7.0', depends=('bar',), build_number=0)
+        index.add_pkg('foo', '3.5.0', depends=('bar',), build_number=0)
+        index.add_pkg('bar', '1.2', build_number=0)
 
         with tempdir() as tmp:
             channel = index.write_to_channel(tmp)
@@ -51,7 +51,7 @@ class Test_resolve_spec(unittest.TestCase):
                                 env:
                                     - python
                                 """) as specfile:
-            with self.assertRaises(conda.resolve.NoPackagesFound):
+            with self.assertRaises(NoPackagesFound):
                 pkgs = resolve_spec(specfile)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gitpython
 pyyaml
-conda-build-all !=1.0.2
-conda-build ==2.0.6
-requests <2.12.0
+conda-build-all
+conda-build
+requests


### PR DESCRIPTION
This PR updates `conda-gitenv` to work with `conda` version `4.3`, which is now enforced as the minimum supported version.

The following `conda` API changes from `4.3` (onwards?), have motivated the need to raise the minimum supported version.

| conda 4.1 | conda 4.2 | conda 4.3 |
|:---|:---:|:---:|
| `conda.install.linked` | `conda.install.linked` | `conda.install.linked` or `conda.exports.linked` or `conda.core.linked_data.linked` |
| `conda.install.unlink` | `conda.install.unlink` | :x: |
| :x: | `conda.model.channel.prioritize_channel` | `conda.model.channel.prioritize_channel` |
| `conda.fetch.fetch_index` | `conda.fetch.fetch_index` | `conda.fetch.fetch_index` or `conda.exports.fetch_index` or `conda.core.index.fetch_index` |
| `conda.installl.is_extracted` | `conda.install.is_extracted` | :x: |
| `conda.install.is_fetched` | `conda.install.is_fetched` | :x: |
| `conda.fetch.fetch_pkg` | `conda.fetch.fetch_pkg` | :x: |
| `conda.install.extract` | `conda.install.extract` | :x: |
| `conda.install.link` | `conda.install.link` | :x: |

I don't think that there is benefit in maintaining the overhead within `conda-gitenv` of supporting `conda` versions prior to `4.3`.