### PR TITLE
Dependency sort packages so manifest is in the correct order

### DIFF
--- a/conda_gitenv/resolve.py
+++ b/conda_gitenv/resolve.py
@@ -36,11 +36,13 @@ def resolve_spec(spec_fh):
     env_spec = spec.get('env', [])
     index = conda.api.get_index(spec.get('channels', []), prepend=False, use_cache=False)
     resolver = conda.resolve.Resolve(index)
-    packages = sorted(resolver.solve(env_spec),
-                      key=lambda pkg: pkg.dist_name.lower())
+    packages = resolver.solve(env_spec)
+    # Use the resolver to sort packages into the appropriate dependency
+    # order.
+    sorted_packages = resolver.dependency_sort({dist.name: dist for dist in packages})
 
     pkgs = []
-    for pkg in packages:
+    for pkg in sorted_packages:
         pkg_info = index[pkg]
         pkgs.append('\t'.join([pkg_info['channel'],
                                pkg_info['fn'][:-len('.tar.bz2')]])), 


### PR DESCRIPTION
Rather than having to sort the packages into the correct order at install time (e.g. with conda_rpms/conda_gitenv.deploy) it makes more sense for the manifest to be presorted in the correct order

I have not written tests for this, but I have tested this locally with my own bitbucket repo and it works as expected