### PR TITLE
add cloud api-key support

### DIFF
--- a/conda_gitenv/deploy.py
+++ b/conda_gitenv/deploy.py
@@ -65,7 +65,8 @@ def deploy_tag(repo, tag_name, target, api_user=None, api_key=None,
     # Replace the channel URL with the mirror URL for each package
     # entry specified in the manifest.
     if mirror is not None:
-        manifest = [[mirror, pkg] for channel, pkg in manifest]
+        manifest = [[os.path.join(mirror, os.path.basename(channel)), pkg]
+                    for channel, pkg in manifest]
 
     target = os.path.join(target, env_name, deployed_name)
     create_env(repo, manifest, target, api_user=api_user, api_key=api_key,
@@ -257,9 +258,17 @@ def handle_args(args):
     with tempdir() as repo_directory:
         repo = Repo.clone_from(args.repo_uri, repo_directory)
         create_tracking_branches(repo)
+
+        mirror = args.mirror
+        if mirror is not None and os.path.isdir(mirror):
+            # For convenience, add the "file" scheme to a raw directory
+            # to make it a well formed URL.
+            mirror = os.path.abspath(os.path.expanduser(mirror))
+            mirror = "file:/{}".format(os.path.normpath(mirror))
+
         deploy_repo(repo, args.target, env_labels=args.env_labels,
                     api_user=args.api_user, api_key=args.api_key,
-                    mirror=args.mirror)
+                    mirror=mirror)
 
 
 def main():

--- a/conda_gitenv/resolve.py
+++ b/conda_gitenv/resolve.py
@@ -71,6 +71,9 @@ def build_manifest_branches(repo, api_user=None, api_key=None, envs=None):
     for remote in repo.remotes:
         remote.fetch()
 
+    if envs is None:
+        envs = ['*']
+
     for branch in repo.branches:
         name = branch.name
         if name.startswith(manifest_branch_prefix):
@@ -79,8 +82,6 @@ def build_manifest_branches(repo, api_user=None, api_key=None, envs=None):
             warnings.warn('Branch {} cannot be resolved as it contains at '
                           'least one "-" character.'.format(name))
             continue
-        if envs is None:
-            envs = ['*']
         if not any([fnmatch(name, env) for env in envs]):
             # Skip non-specific environments.
             continue

--- a/conda_gitenv/resolve.py
+++ b/conda_gitenv/resolve.py
@@ -30,8 +30,8 @@ from conda_gitenv import manifest_branch_prefix
 
 def resolve_spec(spec_fh, api_user, api_key):
     """
-    Given an open file handle to an env.spec, return a list of strings containing
-    '<channel_url>\t<pkg_name>' for each package resolved.
+    Given an open file handle to an env.spec, return a list of strings
+    containing '<channel_url>\t<pkg_name>' for each package resolved.
 
     """
     try:
@@ -49,7 +49,8 @@ def resolve_spec(spec_fh, api_user, api_key):
     if api_user and api_key:
         for i, url in enumerate(channels):
             parts = urlparse(url)
-            api_url = '{}://{}:{}@{}{}'.format(parts.scheme, api_user, api_key, parts.netloc, parts.path)
+            api_url = '{}://{}:{}@{}{}'.format(parts.scheme, api_user, api_key,
+                                               parts.netloc, parts.path)
             channels[i] = api_url
 
     index = conda.api.get_index(channels, prepend=False, use_cache=False)
@@ -60,8 +61,9 @@ def resolve_spec(spec_fh, api_user, api_key):
     pkgs = []
     for pkg in packages:
         pkg_info = index[pkg]
-        pkgs.append('\t'.join([os.path.join(pkg_info['schannel'], pkg_info['subdir']),
-                               pkg_info['fn'][:-len('.tar.bz2')]])), 
+        pkgs.append('\t'.join([os.path.join(pkg_info['schannel'],
+                                            pkg_info['subdir']),
+                               pkg_info['fn'][:-len('.tar.bz2')]]))
     return pkgs
 
 
@@ -114,7 +116,10 @@ def build_manifest_branches(repo, api_user=None, api_key=None, envs=None):
 
 @contextlib.contextmanager
 def tempdir(prefix='tmp'):
-    """A context manager for creating and then deleting a temporary directory."""
+    """
+    A context manager for creating and then deleting a temporary directory.
+
+    """
     tmpdir = tempfile.mkdtemp(prefix=prefix)
     try:
         yield tmpdir
@@ -140,7 +145,8 @@ def create_tracking_branches(repo):
 
 
 def configure_parser(parser):
-    parser.add_argument('repo_uri', help='Repo to use for environment tracking.')
+    msg = 'Repo to use for environment tracking.'
+    parser.add_argument('repo_uri', help=msg)
     parser.add_argument('--verbose', '-v', action='store_true')
     parser.add_argument('--api_user', '-u', action='store',
                         help='the API user')
@@ -165,7 +171,8 @@ def handle_args(args):
             for branch in repo.branches:
                 if branch.name.startswith(manifest_branch_prefix):
                     remote_branch = branch.tracking_branch()
-                    if remote_branch is None or branch.commit != remote_branch.commit:
+                    if (remote_branch is None or
+                            branch.commit != remote_branch.commit):
                         print('Pushing changes to {}'.format(branch.name))
                         repo.remotes.origin.push(branch)
 
@@ -173,7 +180,8 @@ def handle_args(args):
 def main():
     import argparse
 
-    parser = argparse.ArgumentParser(description='Track environment specifications using a git repo.')
+    description = 'Track environment specifications using a git repo.'
+    parser = argparse.ArgumentParser(description=description)
     configure_parser(parser)
     args = parser.parse_args()
     return args.function(args)

--- a/conda_gitenv/resolve.py
+++ b/conda_gitenv/resolve.py
@@ -12,6 +12,7 @@ from __future__ import print_function
 
 import datetime
 import contextlib
+from fnmatch import fnmatch
 import logging
 import os
 import shutil
@@ -27,15 +28,31 @@ import yaml
 from conda_gitenv import manifest_branch_prefix
 
 
-def resolve_spec(spec_fh):
+def resolve_spec(spec_fh, api_user, api_key):
     """
     Given an open file handle to an env.spec, return a list of strings containing
     '<channel_url>\t<pkg_name>' for each package resolved.
 
     """
+    try:
+        # Python3...
+        from urllib.parse import urlparse
+    except ImportError:
+        # Python2...
+        from urlparse import urlparse
+
     spec = yaml.safe_load(spec_fh)
     env_spec = spec.get('env', [])
-    index = conda.api.get_index(spec.get('channels', []), prepend=False, use_cache=False)
+
+    channels = spec.get('channels', [])
+    # Inject the API user and key into the channel URLs...
+    if api_user and api_key:
+        for i, url in enumerate(channels):
+            parts = urlparse(url)
+            api_url = '{}://{}:{}@{}{}'.format(parts.scheme, api_user, api_key, parts.netloc, parts.path)
+            channels[i] = api_url
+
+    index = conda.api.get_index(channels, prepend=False, use_cache=False)
     resolver = conda.resolve.Resolve(index)
     packages = sorted(resolver.solve(env_spec),
                       key=lambda pkg: pkg.dist_name.lower())
@@ -43,12 +60,12 @@ def resolve_spec(spec_fh):
     pkgs = []
     for pkg in packages:
         pkg_info = index[pkg]
-        pkgs.append('\t'.join([pkg_info['channel'],
+        pkgs.append('\t'.join([os.path.join(pkg_info['schannel'], pkg_info['subdir']),
                                pkg_info['fn'][:-len('.tar.bz2')]])), 
     return pkgs
 
 
-def build_manifest_branches(repo):
+def build_manifest_branches(repo, api_user=None, api_key=None, envs=None):
     for remote in repo.remotes:
         remote.fetch()
 
@@ -60,13 +77,18 @@ def build_manifest_branches(repo):
             warnings.warn('Branch {} cannot be resolved as it contains at '
                           'least one "-" character.'.format(name))
             continue
+        if envs is None:
+            envs = ['*']
+        if not any([fnmatch(name, env) for env in envs]):
+            # Skip non-specific environments.
+            continue
         branch.checkout()
         spec_fname = os.path.join(repo.working_dir, 'env.spec')
         if not os.path.exists(spec_fname):
             # Skip branches which don't have a spec.
             continue
         with open(spec_fname, 'r') as fh:
-            pkgs = resolve_spec(fh)
+            pkgs = resolve_spec(fh, api_user, api_key)
             # Cache the contents of the env.spec file from the source branch.
             fh.seek(0)
             spec_lines = fh.readlines()
@@ -120,6 +142,12 @@ def create_tracking_branches(repo):
 def configure_parser(parser):
     parser.add_argument('repo_uri', help='Repo to use for environment tracking.')
     parser.add_argument('--verbose', '-v', action='store_true')
+    parser.add_argument('--api_user', '-u', action='store',
+                        help='the API user')
+    parser.add_argument('--api_key', '-k', action='store',
+                        help='the API key')
+    parser.add_argument('--envs', '-e', nargs='+', default=['*'],
+                        help='the environment names to resolve')
     parser.set_defaults(function=handle_args)
     return parser
 
@@ -132,7 +160,8 @@ def handle_args(args):
         with tempdir() as repo_directory:
             repo = Repo.clone_from(args.repo_uri, repo_directory)
             create_tracking_branches(repo)
-            build_manifest_branches(repo)
+            build_manifest_branches(repo, api_user=args.api_user,
+                                    api_key=args.api_key, envs=args.envs)
             for branch in repo.branches:
                 if branch.name.startswith(manifest_branch_prefix):
                     remote_branch = branch.tracking_branch()

--- a/conda_gitenv/resolve.py
+++ b/conda_gitenv/resolve.py
@@ -19,8 +19,8 @@ import shutil
 import tempfile
 import warnings
 
-import conda.resolve
 import conda.api
+import conda.resolve
 import conda_build_all.version_matrix
 from git import Repo
 import yaml
@@ -43,8 +43,8 @@ def resolve_spec(spec_fh, api_user, api_key):
 
     spec = yaml.safe_load(spec_fh)
     env_spec = spec.get('env', [])
-
     channels = spec.get('channels', [])
+
     # Inject the API user and key into the channel URLs...
     if api_user and api_key:
         for i, url in enumerate(channels):
@@ -148,13 +148,13 @@ def create_tracking_branches(repo):
 def configure_parser(parser):
     msg = 'Repo to use for environment tracking.'
     parser.add_argument('repo_uri', help=msg)
-    parser.add_argument('--verbose', '-v', action='store_true')
-    parser.add_argument('--api_user', '-u', action='store',
-                        help='the API user')
     parser.add_argument('--api_key', '-k', action='store',
                         help='the API key')
+    parser.add_argument('--api_user', '-u', action='store',
+                        help='the API user')
     parser.add_argument('--envs', '-e', nargs='+', default=['*'],
                         help='the environment names to resolve')
+    parser.add_argument('--verbose', '-v', action='store_true')
     parser.set_defaults(function=handle_args)
     return parser
 


### PR DESCRIPTION
This PR adds API user and key injection for channel hosts that require authentication. This is supported through the `--api_user=<user>` and `--api_key=<key>` optional command line arguments.

Note that:
* a resolved environment branch `manifest/<environment-name>/env.manifest` file does not contain any references to the `--api_user` or `--api_key`
* the deployed root directory package-cache `<root-dir>/.pkg_cache/urls.txt` and `.pkg_cache/urls` files are now **read-write** only for the **owner**
* a deployed environment directory `<root-dir>/<environment-name>/conda-meta` is now **read-write** only for the **owner**

The `--api_user` and `--api_key` may be provided to the `conda gitenv resolve` and `conda gitenv deploy` commands only. These options are not required for the `conda gitenv autotag` and `conda gitenv autolabel` commands.

This PR has been extended to include the `--mirror=<url>` optional argument to the `conda gitenv deploy` command, to allow resolved environment manifests to use a `mirror` channel instead of the resolved channels specified in the manifest. This is to support the need for local mirrors to channels that are not directly accessible.